### PR TITLE
Fixed startup script in /etc/rc.local

### DIFF
--- a/cookbooks/basics/templates/default/rc.local.erb
+++ b/cookbooks/basics/templates/default/rc.local.erb
@@ -8,12 +8,10 @@
 # You can put your own initialization stuff in here if you don't
 # want to do the full Sys V style init stuff.
 
-BLUEPILLPATH=`/usr/bin/which bluepill`
-
 touch /var/lock/subsys/local
 
 <% if node['platform_version'].to_i <= 5 %>
-/etc/init.d/rabbitmq-server start > /dev/null && $BLUEPILLPATH load /etc/bluepill/bigcouch.pill && sleep 10 && $BLUEPILLPATH load /etc/bluepill/whapps.pill > /dev/null && sleep 10 && $BLUEPILLPATH load /etc/bluepill/ecallmgr.pill > /dev/null && $BLUEPILLPATH load /etc/bluepill/freeswitch.pill > /dev/null
+/etc/init.d/rabbitmq-server start > /dev/null && /usr/local/rvm/gems/ruby-1.8.7-p370/bin/bluepill load /etc/bluepill/bigcouch.pill && sleep 10 && /usr/local/rvm/gems/ruby-1.8.7-p370/bin/bluepill load /etc/bluepill/whapps.pill > /dev/null && sleep 10 && /usr/local/rvm/gems/ruby-1.8.7-p370/bin/bluepill load /etc/bluepill/ecallmgr.pill > /dev/null && /usr/local/rvm/gems/ruby-1.8.7-p370/bin/bluepill load /etc/bluepill/freeswitch.pill > /dev/null
 <% else %>
-/sbin/start rabbitmq-server > /dev/null && $BLUEPILLPATH load /etc/bluepill/bigcouch.pill && sleep 10 && $BLUEPILLPATH load /etc/bluepill/whapps.pill > /dev/null && sleep 10 && $BLUEPILLPATH load /etc/bluepill/ecallmgr.pill > /dev/null && $BLUEPILLPATH load /etc/bluepill/freeswitch.pill > /dev/null
+/sbin/start rabbitmq-server > /dev/null && /usr/local/rvm/gems/ruby-1.8.7-p370/bin/bluepill load /etc/bluepill/bigcouch.pill && sleep 10 && /usr/local/rvm/gems/ruby-1.8.7-p370/bin/bluepill load /etc/bluepill/whapps.pill > /dev/null && sleep 10 && /usr/local/rvm/gems/ruby-1.8.7-p370/bin/bluepill load /etc/bluepill/ecallmgr.pill > /dev/null && /usr/local/rvm/gems/ruby-1.8.7-p370/bin/bluepill load /etc/bluepill/freeswitch.pill > /dev/null
 <% end %>


### PR DESCRIPTION
Fixed startup script in /etc/rc.local, variables are not set properly at start up so I replaced them with the full path of Bluepill. We'll need to look into this.
