### PR TITLE
OpenSIPs cookbook fix

### DIFF
--- a/cookbooks/opensips/recipes/default.rb
+++ b/cookbooks/opensips/recipes/default.rb
@@ -25,6 +25,8 @@ when "centos", "redhat", "fedora", "amazon"
   packages.each do |pkg|
     package pkg do
       action :install
+      version "1.6.4-8.el6"
+      options "--disablerepo=epel"
     end
   end
   


### PR DESCRIPTION
Fixed OpenSIPs recipe to install the correct version from the 2600Hz repository
