### PR TITLE
Fixed a path issue for the lib directory since recent Kazoo update

### DIFF
--- a/cookbooks/whistle/recipes/rpm.rb
+++ b/cookbooks/whistle/recipes/rpm.rb
@@ -74,7 +74,7 @@ template "#{node[:kazoo][:kazoo_apps_dir]}/priv/startup.config" do
   mode "0644"
 end
 
-template "#{node[:kazoo][:homedir]}/lib/whistle_couch-1.0.0/priv/startup.config" do
+template "#{node[:kazoo][:homedir]}/whistle_apps/lib/whistle_couch-1.0.0/priv/startup.config" do
   source "whistle_couch-1.0.0_priv_startup.config.erb"
   owner "kazoo"
   group "kazoo"


### PR DESCRIPTION
the main lib directory in /opt/kazoo was split and now whistle_couch is in /opt/kazoo/whistle_apps/lib/, this fixes the resulting path issue.
