### PR TITLE
Updated Logrotate::freeswitch from 20 to 120 rotations

### DIFF
--- a/cookbooks/logrotate/recipes/freeswitch.rb
+++ b/cookbooks/logrotate/recipes/freeswitch.rb
@@ -21,7 +21,7 @@ include_recipe "logrotate"
 
 logrotate_app "freeswitch" do
   paths "/var/log/freeswitch/*.log"
-  rotate 20
+  rotate 120
   size "10M"
 end
 


### PR DESCRIPTION
The logs rotate too fast right now on a FreeSWITCH node and we miss clients' log sometime. 120 should allow us to retrieve them even after a weekend.
