### PR TITLE
Updated roles/deploy_base.json to reflect the removal of RVM from the bootstrap script

### DIFF
--- a/roles/deploy_base.json
+++ b/roles/deploy_base.json
@@ -18,7 +18,6 @@
   },
   "run_list": [
     "recipe[yumrepo]",
-    "role[rvm]",
     "recipe[selinux]",
     "recipe[postfix]",
     "recipe[basics]",
@@ -28,7 +27,6 @@
     "recipe[basics::iptables_disable]",
     "recipe[logrotate::local0]",
     "recipe[logrotate::chef-client]",
-    "recipe[basics::startup]"
   ],
   "description": "Base Centos role for the winkstart deploy tool",
   "chef_type": "role",


### PR DESCRIPTION
We removed RVM from our bootstrap script, so the role "deploy_base" needed to be updated to reflect this change.
