### PR TITLE
Set a defaut and a failover AMQP server.

### DIFF
--- a/cookbooks/whistle/recipes/rpm.rb
+++ b/cookbooks/whistle/recipes/rpm.rb
@@ -86,6 +86,7 @@ template "#{node[:kazoo][:homedir]}/lib/whistle_amqp-1.0.0/priv/startup.config" 
   owner "kazoo"
   group "kazoo"
   mode "0644"
+  variables :fs_nodes => fs_nodes
 end
 
 template "#{node[:kazoo][:homedir]}/ecallmgr/conf/vm.args" do

--- a/cookbooks/whistle/templates/default/whistle_amqp-1.0.0_priv_startup.config.erb
+++ b/cookbooks/whistle/templates/default/whistle_amqp-1.0.0_priv_startup.config.erb
@@ -1,5 +1,5 @@
 <% if node.has_key?("whistle_amqp_ip") %>
   {amqp_uri, "amqp://guest:guest@<%= node[:whistle_amqp_ip] %>:5672"}.
 <% else %>
-  {amqp_uri, "amqp://guest:guest@<%= node[:ipaddress] %>:5672"}.
+  <%= @fs_nodes['whapps']['servers'].map{|k,v| "\'amqp://guest:guest\@#{v}:5672\'"}.join(',') %>
 <% end %>


### PR DESCRIPTION
Set a defaut and a failover AMQP server in preparation for the general config.ini file.
