### PR TITLE
Reverted Erlang package to default one on Sensu branch

### DIFF
--- a/cookbooks/erlang/recipes/default.rb
+++ b/cookbooks/erlang/recipes/default.rb
@@ -43,7 +43,7 @@ when "centos", "redhat", "fedora"
           arch "x86_64"
         end
   end
-  package "esl-erlang"
+  package "erlang"
 when "amazon"
-  package "esl-erlang"
+  package "erlang"
 end


### PR DESCRIPTION
The official RabbitMQ package (https://www.rabbitmq.com/releases/rabbitmq-server/v2.8.4/rabbitmq-server-2.8.4-1.noarch.rpm) doesn't like erlang solution rpm so we'll revert it for now, it doesn't really matter on the Sensu branch, only for the regular Kazoo one.
