### PR TITLE
Modified check_sip recipe to use IP address as host argument instead of ...

### DIFF
--- a/cookbooks/chef-monitor/recipes/check_sip.rb
+++ b/cookbooks/chef-monitor/recipes/check_sip.rb
@@ -26,7 +26,7 @@ cookbook_file "etc/sensu/plugins/check_sip.rb" do
 end
 
 sensu_check "check_sip" do
-  command "check_sip.rb -H #{node['fqdn']} -u sip:1234@#{node['ipaddress']} -p 5060"
+  command "check_sip.rb -H #{node['ipaddress']} -u sip:1234@#{node['ipaddress']} -p 5060"
   handlers ["default"]
   subscribers ["sip"]
   interval 30


### PR DESCRIPTION
...FQDN, as it seems less prone to errors.
